### PR TITLE
Cleanup tables

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("", views.HomeView, name="home"),
     path("ajax_calls/search/", views.autocompleteModel, name="search"),
     path("search_results/<str:query>", views.search, name="results"),
+    path("index/", views.index, name="index"),
     path(
         "about/", TemplateView.as_view(template_name="pages/about.html"), name="about"
     ),

--- a/config/views.py
+++ b/config/views.py
@@ -7,12 +7,17 @@ from django.views import generic
 from django.views.generic import DetailView, ListView, RedirectView, UpdateView
 from django.http import HttpResponse
 from django.db.models import Q
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+
 
 import json
 
+from toxsign.assays.models import Assay
 from toxsign.projects.models import Project
-from toxsign.studies.models import Study
 from toxsign.signatures.models import Signature
+from toxsign.studies.models import Study
+
+
 
 def HomeView(request):
         context = {}
@@ -32,6 +37,65 @@ def autocompleteModel(request):
         'signatures': results_signatures
     }
     return render(request, 'pages/ajax_search.html', {'statuss': results})
+
+def index(request):
+    projects = Project.objects.all().order_by('id')
+    project_number = len(projects)
+    paginator = Paginator(projects, 5)
+    page = request.GET.get('projects')
+    try:
+        Model_one = paginator.page(page)
+    except PageNotAnInteger:
+        Model_one = paginator.page(1)
+    except EmptyPage:
+        Model_one = paginator.page(paginator.num_pages)
+
+    studies = Study.objects.all()
+    study_number = len(studies)
+    paginator = Paginator(studies, 6)
+    page = request.GET.get('studies')
+    try:
+        studies = paginator.page(page)
+    except PageNotAnInteger:
+        studies = paginator.page(1)
+    except EmptyPage:
+        studies = paginator.page(paginator.num_pages)
+
+    assays = Assay.objects.all()
+    study_number = len(assays)
+    paginator = Paginator(assays, 6)
+    page = request.GET.get('assays')
+    try:
+        assays = paginator.page(page)
+    except PageNotAnInteger:
+        assays = paginator.page(1)
+    except EmptyPage:
+        assays = paginator.page(paginator.num_pages)
+
+    signatures = Signature.objects.all()
+    study_number = len(signatures)
+    paginator = Paginator(signatures, 6)
+    page = request.GET.get('signatures')
+    try:
+        signatures = paginator.page(page)
+    except PageNotAnInteger:
+        signatures = paginator.page(1)
+    except EmptyPage:
+        signatures = paginator.page(paginator.num_pages)
+
+    context = {
+        'project_list': projects,
+        'study_list': studies,
+        'assay_list': assays,
+        'signature_list': signatures,
+        'project_number':project_number,
+        'study_number': study_number,
+        'assay_number': assay_number,
+        'signature_number': signature_number
+    },
+    
+    return render(request, 'projects/index.html', context)
+
 
 def search(request,query):
     print(query)

--- a/config/views.py
+++ b/config/views.py
@@ -62,7 +62,7 @@ def index(request):
         studies = paginator.page(paginator.num_pages)
 
     assays = Assay.objects.all()
-    study_number = len(assays)
+    assay_number = len(assays)
     paginator = Paginator(assays, 6)
     page = request.GET.get('assays')
     try:
@@ -73,7 +73,7 @@ def index(request):
         assays = paginator.page(paginator.num_pages)
 
     signatures = Signature.objects.all()
-    study_number = len(signatures)
+    signature_number = len(signatures)
     paginator = Paginator(signatures, 6)
     page = request.GET.get('signatures')
     try:
@@ -92,9 +92,9 @@ def index(request):
         'study_number': study_number,
         'assay_number': assay_number,
         'signature_number': signature_number
-    },
+    }
     
-    return render(request, 'projects/index.html', context)
+    return render(request, 'pages/index.html', context)
 
 
 def search(request,query):

--- a/toxsign/assays/admin.py
+++ b/toxsign/assays/admin.py
@@ -7,7 +7,6 @@ class AssayAdmin(admin.ModelAdmin):
     fieldsets = [
         (None,               {'fields': [
             'name', 
-            'tsx_id',
             'created_by', 
             'status', 
             'additional_info', 
@@ -16,12 +15,11 @@ class AssayAdmin(admin.ModelAdmin):
             'generation', 
             'sex_type', 
             'exp_type', 
-            'prj_subClass', 
-            'std_subClass', 
+            'study', 
             'organism', 
             'tissue', 
             'cell', 
-            'cell_ligne'
+            'cell_line'
         ]}),
     ]
     list_display = ['name', 'created_at', 'updated_at']
@@ -31,7 +29,6 @@ class FactorAdmin(admin.ModelAdmin):
     fieldsets = [
         (None,               {'fields': [
             'name', 
-            'tsx_id',
             'created_by', 
             'chemical', 
             'chemical_slug', 
@@ -42,7 +39,8 @@ class FactorAdmin(admin.ModelAdmin):
             'dose_unit', 
             'exposure_time', 
             'exposure_frequencie', 
-            'additional_info', 
+            'additional_info',
+            'assay' 
         ]}),
     ]
     list_display = ['name', 'created_at', 'updated_at']

--- a/toxsign/assays/tests/test_urls.py
+++ b/toxsign/assays/tests/test_urls.py
@@ -7,10 +7,6 @@ from toxsign.assays.tests.factories import AssayFactory
 
 pytestmark = pytest.mark.django_db
 
-def test_list():
-    assert reverse("assays:index") == "/assays/"
-    assert resolve("/assays/").view_name == "assays:index"
-
 def test_details():
     assay = AssayFactory.create()
     assert (

--- a/toxsign/assays/urls.py
+++ b/toxsign/assays/urls.py
@@ -3,6 +3,5 @@ from toxsign.assays import views
 
 app_name = "assays"
 urlpatterns = [
-    path('', views.IndexView.as_view(), name='index'),
     path('<str:assid>/', views.DetailView, name='detail'),
 ]

--- a/toxsign/assays/views.py
+++ b/toxsign/assays/views.py
@@ -8,19 +8,6 @@ from django.views.generic import DetailView, ListView, RedirectView, UpdateView
 from toxsign.assays.models import Assay, Factor
 
 
-class IndexView(generic.ListView):
-    template_name = 'assays/index.html'
-    context_object_name = 'study_list'
-
-    def get_queryset(self):
-        """
-        Return the last five published questions (not including those set to be
-        published in the future).
-        """
-        return Assay.objects.filter(
-            created_at__lte=timezone.now()
-        ).order_by('created_at')
-
 class DetailView(LoginRequiredMixin, DetailView):
     template_name = 'assays/details.html'
     model = Assay

--- a/toxsign/projects/tests/test_urls.py
+++ b/toxsign/projects/tests/test_urls.py
@@ -7,9 +7,6 @@ from toxsign.projects.tests.factories import ProjectFactory
 
 pytestmark = pytest.mark.django_db
 
-def test_list():
-    assert reverse("projects:index") == "/projects/"
-    assert resolve("/projects/").view_name == "projects:index"
 
 def test_details():
     project = ProjectFactory.create()

--- a/toxsign/projects/tests/test_views.py
+++ b/toxsign/projects/tests/test_views.py
@@ -10,15 +10,6 @@ from toxsign.projects.views import EditView
 
 pytestmark = pytest.mark.django_db
 
-class TestProjectListView:
-
-    def test_list_view(self, client):
-        project = ProjectFactory.create()
-        response = client.get(reverse('projects:index'))
-        projects = response.context['project_list']
-        assert len(projects) == 1
-        new_project = projects[0]
-        assert new_project.name == project.name
 
 class TestProjectDetailView:
 

--- a/toxsign/projects/urls.py
+++ b/toxsign/projects/urls.py
@@ -3,7 +3,6 @@ from toxsign.projects import views
 
 app_name = "projects"
 urlpatterns = [
-    path('', views.IndexView, name='index'),
     path('<str:prjid>/', views.DetailView, name='detail'),
     path('project_edit/<int:pk>/', views.EditView.as_view(), name='project_edit'),
 ]

--- a/toxsign/projects/views.py
+++ b/toxsign/projects/views.py
@@ -17,8 +17,15 @@ def DetailView(request, prjid):
     project_object = Project.objects.get(tsx_id=prjid)
     project = get_object_or_404(Project, pk=project_object.id)
     studies = project.study_of.all()
-    print(studies)
-    return render(request, 'projects/details.html', {'project': project,'studies':studies})
+    assays = []
+    for study in studies:
+        assays = assays + [assay for assay in study.assay_of.all()]
+    signatures = []
+    for assay in assays:
+        for factor in assay.factor_of.all():
+            signatures = signatures + [factor for factor in factor.signature_of_of.all()]
+
+    return render(request, 'projects/details.html', {'project': project,'studies': studies, 'assays': assays, 'signatures': signatures})
 
 class EditView(LoginRequiredMixin, UpdateView):
 

--- a/toxsign/projects/views.py
+++ b/toxsign/projects/views.py
@@ -13,32 +13,6 @@ from toxsign.studies.models import Study
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 
-def IndexView(request):
-    Model_one = Project.objects.all().order_by('id')
-    project_number = len(Model_one)
-    paginator = Paginator(Model_one, 5)
-    page = request.GET.get('projects')
-    try:
-        Model_one = paginator.page(page)
-    except PageNotAnInteger:
-        Model_one = paginator.page(1)
-    except EmptyPage:
-        Model_one = paginator.page(paginator.num_pages)
-
-    Model_two = Study.objects.all()
-    study_number = len(Model_two)
-    paginator = Paginator(Model_two, 6)
-    page = request.GET.get('studies')
-    try:
-        Model_two = paginator.page(page)
-    except PageNotAnInteger:
-        Model_two = paginator.page(1)
-    except EmptyPage:
-        Model_two = paginator.page(paginator.num_pages)
-
-    context = {'project_list': Model_one, 'study_list': Model_two, 'project_number':project_number, 'study_number':study_number}
-    return render(request, 'projects/index.html', context)
-
 def DetailView(request, prjid):
     project_object = Project.objects.get(tsx_id=prjid)
     project = get_object_or_404(Project, pk=project_object.id)

--- a/toxsign/signatures/admin.py
+++ b/toxsign/signatures/admin.py
@@ -6,7 +6,6 @@ from toxsign.signatures.models import Signature
 class SignatureAdmin(admin.ModelAdmin):
     fieldsets = [
         (None,               {'fields': ['name', 
-        'tsx_id', 
         'created_by',
         'status',
         'signature_type',
@@ -16,14 +15,11 @@ class SignatureAdmin(admin.ModelAdmin):
         'generation',
         'sex_type',
         'exp_type',
-        'prj_subClass',
-        'std_subClass',
-        'ass_subClass',
-        'ftc_subClass',
+        'factor',
         'organism',
         'tissue',
         'cell',
-        'cell_ligne',
+        'cell_line',
         'chemical',
         'chemical_slug',
         'disease',
@@ -42,6 +38,7 @@ class SignatureAdmin(admin.ModelAdmin):
         'gene_id',
     ]}),
     ]
+    autocomplete_fields = ['disease']
     list_display = ['name', 'created_at', 'updated_at']
     search_fields = ['name']
 

--- a/toxsign/signatures/tests/test_urls.py
+++ b/toxsign/signatures/tests/test_urls.py
@@ -7,10 +7,6 @@ from toxsign.signatures.tests.factories import SignatureFactory
 
 pytestmark = pytest.mark.django_db
 
-def test_list():
-    assert reverse("signatures:index") == "/signatures/"
-    assert resolve("/signatures/").view_name == "signatures:index"
-
 def test_details():
     signature = SignatureFactory.create()
     assert (

--- a/toxsign/signatures/urls.py
+++ b/toxsign/signatures/urls.py
@@ -3,6 +3,5 @@ from toxsign.signatures import views
 
 app_name = "signatures"
 urlpatterns = [
-    path('', views.IndexView.as_view(), name='index'),
     path('<str:sigid>/', views.DetailView.as_view(), name='detail'),
 ]

--- a/toxsign/signatures/views.py
+++ b/toxsign/signatures/views.py
@@ -8,19 +8,6 @@ from django.views.generic import DetailView, ListView, RedirectView, UpdateView
 from toxsign.signatures.models import Signature
 
 
-class IndexView(generic.ListView):
-    template_name = 'signature/index.html'
-    context_object_name = 'signatures'
-
-    def get_queryset(self):
-        """
-        Return the last five published questions (not including those set to be
-        published in the future).
-        """
-        return Signature.objects.filter(
-            created_at__lte=timezone.now()
-        ).order_by('created_at')
-
 class DetailView(LoginRequiredMixin, DetailView):
     template_name = 'signature/details.html'
     model = Signature

--- a/toxsign/studies/tests/test_urls.py
+++ b/toxsign/studies/tests/test_urls.py
@@ -7,10 +7,6 @@ from toxsign.studies.tests.factories import StudyFactory
 
 pytestmark = pytest.mark.django_db
 
-def test_list():
-    assert reverse("studies:index") == "/studies/"
-    assert resolve("/studies/").view_name == "studies:index"
-
 def test_details():
     study = StudyFactory.create()
     assert (

--- a/toxsign/studies/urls.py
+++ b/toxsign/studies/urls.py
@@ -3,7 +3,6 @@ from toxsign.studies import views
 
 app_name = "studies"
 urlpatterns = [
-    path('', views.IndexView.as_view(), name='index'),
     path('<str:stdid>/', views.DetailView.as_view(), name='detail'),
     path('study_edit/<int:pk>/', views.EditView.as_view(), name='study_edit'),
 ]

--- a/toxsign/studies/views.py
+++ b/toxsign/studies/views.py
@@ -10,11 +10,6 @@ from toxsign.studies.models import Study
 
 User = get_user_model()
 
-class IndexView(ListView):
-    template_name = 'studies/index.html'
-    context_object_name = 'studies_list'
-    model = Study
-
 class DetailView(LoginRequiredMixin, DetailView):
     template_name = 'studies/details.html'
     model = Study

--- a/toxsign/templates/base.html
+++ b/toxsign/templates/base.html
@@ -47,7 +47,7 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'projects:index' %}"><i class="fas fa-database"></i> Browse <span class="sr-only">(current)</span></a>
+              <a class="nav-link" href="{% url 'index' %}"><i class="fas fa-database"></i> Browse <span class="sr-only">(current)</span></a>
             </li>
             <li class="nav-item dropdown {% if request.resolver_match.url_name == 'about' or request.resolver_match.url_name == 'studies' or request.resolver_match.url_name == 'statistics' or request.resolver_match.url_name == 'citing' or request.resolver_match.url_name == 'contact' %} active {% endif %}">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/toxsign/templates/pages/index.html
+++ b/toxsign/templates/pages/index.html
@@ -8,8 +8,9 @@
           <div class="list-group ">
               <a href="#tab1" data-toggle="tab" class="list-group-item list-group-item-action active">Projects ({{ project_number }})</a>
               <a href="#tab2" data-toggle="tab" class="list-group-item list-group-item-action">Studies ({{ study_number }})</a>
-              <a href="#tab3" data-toggle="tab" class="list-group-item list-group-item-action">Signatures</a>
-            </div> 
+              <a href="#tab3" data-toggle="tab" class="list-group-item list-group-item-action">Assays ({{ assay_number }})</a>
+              <a href="#tab4" data-toggle="tab" class="list-group-item list-group-item-action">Signatures ({{ signature_number }})</a>
+            </div>
         </div>
         <div class="col-md-9">
             <div class="tab-content card">
@@ -74,15 +75,72 @@
                     </ul>
                 </nav>
                 {% endif %}
-                  
+
               </div>
               <div class="tab-pane text-style card-body" id="tab3">
-                
+                {% for assay in assay_list %}
+                      <h3><a href="{% url 'assays:detail' assay.tsx_id %}">{{ assay.tsx_id }}</a> - {{assay.name}}</h3>
+                      <small><b>Author:</b>{{ assay.created_by }} - {{ assay.created_at }}</small>
+                      <hr>
+                  {% endfor %}
+                  {% if assay_list %}
+                  <nav aria-label="Page navigation example">
+                    <ul class="pagination">
+                      {% if assay_list.has_previous %}
+                        <li class="page-item"><a class="page-link" href="?assays={{ assay_list.previous_page_number }}">&laquo;</a></li>
+                      {% else %}
+                        <li class="page-item disabled"><a class="page-link"><span>&laquo;</span></a></li>
+                      {% endif %}
+                      {% for i in assay_list.paginator.page_range %}
+                        {% if assay_list.number == i %}
+                          <li class="page-item active"><a class="page-link"><span>{{ i }} <span class="sr-only">(current)</span></span></a></li>
+                        {% else %}
+                          <li class="page-item"><a class="page-link" href="?assays={{ i }}">{{ i }}</a></li>
+                        {% endif %}
+                      {% endfor %}
+                      {% if assay_list.has_next %}
+                        <li class="page-item"><a class="page-link" href="?assays={{ assay_list.next_page_number }}">&raquo;</a></li>
+                      {% else %}
+                        <li class="page-item disabled"><a class="page-link"><span>&raquo;</span></a></li>
+                      {% endif %}
+                    </ul>
+                </nav>
+                {% endif %}
+              </div>
+              <div class="tab-pane text-style card-body" id="tab4">
+                {% for signature in signature_list %}
+                      <h3><a href="{% url 'signatures:detail' signature.tsx_id %}">{{ signature.tsx_id }}</a> - {{signature.name}}</h3>
+                      <small><b>Author:</b>{{ signature.created_by }} - {{ signature.created_at }}</small>
+                      <hr>
+                  {% endfor %}
+                  {% if signature_list %}
+                  <nav aria-label="Page navigation example">
+                    <ul class="pagination">
+                      {% if signature_list.has_previous %}
+                        <li class="page-item"><a class="page-link" href="?signatures={{ signature_list.previous_page_number }}">&laquo;</a></li>
+                      {% else %}
+                        <li class="page-item disabled"><a class="page-link"><span>&laquo;</span></a></li>
+                      {% endif %}
+                      {% for i in signature_list.paginator.page_range %}
+                        {% if signature_list.number == i %}
+                          <li class="page-item active"><a class="page-link"><span>{{ i }} <span class="sr-only">(current)</span></span></a></li>
+                        {% else %}
+                          <li class="page-item"><a class="page-link" href="?signatures={{ i }}">{{ i }}</a></li>
+                        {% endif %}
+                      {% endfor %}
+                      {% if signature_list.has_next %}
+                        <li class="page-item"><a class="page-link" href="?signatures={{ signature_list.next_page_number }}">&raquo;</a></li>
+                      {% else %}
+                        <li class="page-item disabled"><a class="page-link"><span>&raquo;</span></a></li>
+                      {% endif %}
+                    </ul>
+                </nav>
+                {% endif %}
               </div>
             </div>
         </div>
       </div>
-        
+
     </div>
 
 {% endblock %}

--- a/toxsign/templates/projects/details.html
+++ b/toxsign/templates/projects/details.html
@@ -8,7 +8,8 @@
           <div class="list-group ">
               <a href="#tab1" data-toggle="tab" class="list-group-item list-group-item-action active">Project</a>
               <a href="#tab2" data-toggle="tab" class="list-group-item list-group-item-action">Studies ({{ studies|length }})</a>
-              <a href="#tab3" data-toggle="tab" class="list-group-item list-group-item-action">Signatures</a>
+              <a href="#tab3" data-toggle="tab" class="list-group-item list-group-item-action">Assays ({{ assays|length }})</a>
+              <a href="#tab4" data-toggle="tab" class="list-group-item list-group-item-action">Signatures ({{ signatures|length }})</a>
             </div> 
         </div>
         <div class="col-md-9">
@@ -28,15 +29,17 @@
                   {% endfor %}
               </div>
               <div class="tab-pane text-style card-body" id="tab3">
-                <h2>Stet clita </h2>
-                <p>Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem vel eum 
-                  iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla 
-                  facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit 
-                  augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet,</p>
+                {% for assay in assays %}
+                  <h2>{{ assay.tsx_id }} - {{ assay.name }}</h2>
                   <hr>
-                  <div class="col-xs-6 col-md-3">
-                    <img src="http://placehold.it/150x150" class="img-rounded pull-right">
-                </div>
+                {% endfor %}              
+              </div>
+              <div class="tab-pane text-style card-body" id="tab4">
+                {% for signature in signatures %}
+                  <h2>{{ signature.tsx_id }} - {{ signature.name }}</h2>
+                  <hr>
+                {% endfor %}
+              
               </div>
             </div>
         </div>


### PR DESCRIPTION
Move index to /index (from /projects/)

Removed listing view for entities


Added basic view for project, querying all entities (might be a cleaner way to do it)